### PR TITLE
Operator envs

### DIFF
--- a/bindata/operator/operator.yaml
+++ b/bindata/operator/operator.yaml
@@ -76,6 +76,12 @@ spec:
         env:
         - name: OPENSTACK_RELEASE_VERSION
           value: '{{ .OpenstackReleaseVersion }}'
+        - name: LEASE_DURATION
+          value: '{{ .OperatorLeaseDuration }}'
+        - name: RENEW_DEADLINE
+          value: '{{ .OperatorRenewDeadline }}'
+        - name: RETRY_PERIOD
+          value: '{{ .OperatorRetryPeriod }}'
 {{ range $envName, $envValue := .OpenStackServiceRelatedImages }}
         - name: {{ $envName }}
           value: {{ $envValue }}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -42,7 +42,8 @@ import (
 
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	operatorv1beta1 "github.com/openstack-k8s-operators/openstack-operator/apis/operator/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/operator"
+	operatorv1 "github.com/openstack-k8s-operators/openstack-operator/apis/operator/v1beta1"
 	operatorcontrollers "github.com/openstack-k8s-operators/openstack-operator/controllers/operator"
 )
 
@@ -53,7 +54,7 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(operatorv1beta1.AddToScheme(scheme))
+	utilruntime.Must(operatorv1.AddToScheme(scheme))
 }
 
 func main() {
@@ -87,7 +88,7 @@ func main() {
 		c.NextProtos = []string{"http/1.1"}
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	options := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
@@ -111,7 +112,15 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
-	})
+	}
+
+	err = operator.SetManagerOptions(&options, setupLog)
+	if err != nil {
+		setupLog.Error(err, "unable to set manager options")
+		os.Exit(1)
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,6 +44,12 @@ spec:
         env:
         - name: OPENSTACK_RELEASE_VERSION
           value: '{{ .OpenstackReleaseVersion }}'
+        - name: LEASE_DURATION
+          value: "137"
+        - name: RENEW_DEADLINE
+          value: "107"
+        - name: RETRY_PERIOD
+          value: "26"
         envCustomImage: replace_me #NOTE: this is used via the Makefile to inject a custom template loop that kustomize won't allow
         image: '{{ .OperatorImage }}'
         name: manager

--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ import (
 	machineconfig "github.com/openshift/api/machineconfiguration/v1"
 	ocp_image "github.com/openshift/api/operator/v1alpha1"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/operator"
 	clientcontrollers "github.com/openstack-k8s-operators/openstack-operator/controllers/client"
 	corecontrollers "github.com/openstack-k8s-operators/openstack-operator/controllers/core"
 	dataplanecontrollers "github.com/openstack-k8s-operators/openstack-operator/controllers/dataplane"
@@ -165,7 +166,7 @@ func main() {
 		c.NextProtos = []string{"http/1.1"}
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	options := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
@@ -189,7 +190,15 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
-	})
+	}
+
+	err = operator.SetManagerOptions(&options, setupLog)
+	if err != nil {
+		setupLog.Error(err, "unable to set manager options")
+		os.Exit(1)
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable leader election parameters for the operator by wiring new environment variables through the setup and deployment, and refactor application startup to leverage lib-common for manager options.

New Features:
- Add LEASE_DURATION, RENEW_DEADLINE, and RETRY_PERIOD environment variables to configure operator leader election timeouts

Enhancements:
- Refactor SetupEnv to use strings.SplitN and a switch statement for more robust environment variable parsing
- Centralize manager configuration by replacing inline ctrl.Options with operator.SetManagerOptions in both main applications

Deployment:
- Update operator deployment templates and manager config to include the new lease, renew deadline, and retry period environment variables